### PR TITLE
api auth

### DIFF
--- a/load/api/permissions.py
+++ b/load/api/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework.permissions import BasePermission
+
+
+class CanAccess(BasePermission):
+    def has_permission(self, request, view):
+        if view.action in ['accept', 'reject', 'rejected', 'carrier_available', 'carrier_accepted']:
+            return request.user.is_carrier
+        elif view.action in ['create', 'shipper_available', 'shipper_accepted', 'list']:
+            return request.user.is_shipper
+        elif view.action in ['available', 'accepted']:
+            return True
+        return False

--- a/load/api/permissions.py
+++ b/load/api/permissions.py
@@ -3,9 +3,9 @@ from rest_framework.permissions import BasePermission
 
 class CanAccess(BasePermission):
     def has_permission(self, request, view):
-        if view.action in ['accept', 'reject', 'rejected', 'carrier_available', 'carrier_accepted']:
+        if view.action in ['accept', 'reject', 'rejected']:
             return request.user.is_carrier
-        elif view.action in ['create', 'shipper_available', 'shipper_accepted', 'list']:
+        elif view.action in ['create', 'list']:
             return request.user.is_shipper
         elif view.action in ['available', 'accepted']:
             return True

--- a/load/api/serializers.py
+++ b/load/api/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework.serializers import ModelSerializer
 from load.models import Load
-from users.models import Shipper
+from users.models import Shipper, Carrier
 
 
 class ShipperSerializer(ModelSerializer):
@@ -9,8 +9,14 @@ class ShipperSerializer(ModelSerializer):
         fields = ('first_name', 'last_name', 'email')
 
 
+class CarrierSerializer(ModelSerializer):
+    class Meta:
+        model = Carrier
+        fields = ('mc_number',)
+
+
 class ShipperLoadSerializer(ModelSerializer):
-    shipper = ShipperSerializer()
+    carrier = CarrierSerializer()
 
     class Meta:
         model = Load

--- a/load/api/viewsets.py
+++ b/load/api/viewsets.py
@@ -1,15 +1,18 @@
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.response import Response
-from rest_framework import status, permissions
+from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
 from django.shortcuts import get_object_or_404
 from load.models import Load
 from users.models import Carrier
 from load.api.serializers import CarrierLoadSerializer, ShipperLoadSerializer, CreateLoadSerializer
+from .permissions import CanAccess
 
 
 class LoadViewSet(ModelViewSet):
     serializer_class = ''
+    permission_classes = (IsAuthenticated, CanAccess,)
 
     def get_serializer_class(self):
         if self.request.user.is_shipper:
@@ -28,7 +31,6 @@ class LoadViewSet(ModelViewSet):
 
         return Load.objects.all()
 
-
     def create(self, request, *args, **kwargs):
         serializer = CreateLoadSerializer(data=request.data)
         carrier_price_ = request.data["shipper_price"] - round(request.data["shipper_price"] * 5 / 100, 2)
@@ -44,7 +46,6 @@ class LoadViewSet(ModelViewSet):
     @action(methods=['get'], detail=False)
     def available(self, request):
         self.serializer_class = self.get_serializer_class()
-
         if self.request.user.is_shipper:
             return self.shipper_available(request)
 

--- a/load/api/viewsets.py
+++ b/load/api/viewsets.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.authentication import TokenAuthentication
 from django.shortcuts import get_object_or_404
 from load.models import Load
 from users.models import Carrier
@@ -13,6 +14,7 @@ from .permissions import CanAccess
 class LoadViewSet(ModelViewSet):
     serializer_class = ''
     permission_classes = (IsAuthenticated, CanAccess,)
+    authentication_classes = (TokenAuthentication,)
 
     def get_serializer_class(self):
         if self.request.user.is_shipper:

--- a/load/tests.py
+++ b/load/tests.py
@@ -58,8 +58,7 @@ class CarrierAPITestCase(APITestCase):
 
     def setUp(self):
         self.user = Shipper.objects.create_user(
-            email="hireme@loadsmart.com", password="iwilldoagreatjob", is_carrier="1")
-        self.user = Carrier.objects.update_or_create(user=self.user, mc_number="123456789")
+            email="hireme@loadsmart.com", password="iwilldoagreatjob", is_shipper="1")
         self.client.login(email="hireme@loadsmart.com",
                           password="iwilldoagreatjob")
         self.data_ = {
@@ -87,6 +86,12 @@ class CarrierAPITestCase(APITestCase):
             "shipper_price": 1500
         }
         self.client.post(self.url, self.data_, format="json")
+        self.client.logout()
+        self.user = Shipper.objects.create_user(
+            email="carrier@loadsmart.com", password="iwilldoagreatjob", is_carrier="1")
+        self.user = Carrier.objects.update_or_create(user=self.user, mc_number="123456789")
+        self.client.login(email="carrier@loadsmart.com",
+                          password="iwilldoagreatjob")
         self.client.post('/api/loads/2/accept/', format="json")
         self.client.post('/api/loads/3/reject/', format="json")
 

--- a/load/tests.py
+++ b/load/tests.py
@@ -3,6 +3,7 @@ from rest_framework.test import APITestCase, APIClient
 from django.urls import reverse
 from rest_framework import status
 from users.models import Shipper, Carrier
+from rest_framework.authtoken.models import Token
 import datetime
 from collections import OrderedDict
 
@@ -16,8 +17,8 @@ class ShipperAPITestCase(APITestCase):
     def setUp(self):
         self.user = Shipper.objects.create_user(
             email="hireme@loadsmart.com", password="iwilldoagreatjob", is_shipper="1")
-        self.client.login(email="hireme@loadsmart.com",
-                          password="iwilldoagreatjob")
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
         self.data_ = {
             "pickup_date": datetime.date(2019, 4, 11),
             "ref": "963",
@@ -59,8 +60,8 @@ class CarrierAPITestCase(APITestCase):
     def setUp(self):
         self.user = Shipper.objects.create_user(
             email="hireme@loadsmart.com", password="iwilldoagreatjob", is_shipper="1")
-        self.client.login(email="hireme@loadsmart.com",
-                          password="iwilldoagreatjob")
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
         self.data_ = {
             "pickup_date": datetime.date(2019, 4, 11),
             "ref": "963",
@@ -89,9 +90,9 @@ class CarrierAPITestCase(APITestCase):
         self.client.logout()
         self.user = Shipper.objects.create_user(
             email="carrier@loadsmart.com", password="iwilldoagreatjob", is_carrier="1")
+        self.token = Token.objects.create(user=self.user)
         self.user = Carrier.objects.update_or_create(user=self.user, mc_number="123456789")
-        self.client.login(email="carrier@loadsmart.com",
-                          password="iwilldoagreatjob")
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
         self.client.post('/api/loads/2/accept/', format="json")
         self.client.post('/api/loads/3/reject/', format="json")
 

--- a/load/urls.py
+++ b/load/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from . import views
 from rest_framework import routers
 from django.conf.urls import include
-from load.api.viewsets import LoadViewSet#, CarrierLoadViewSet
+from load.api.viewsets import LoadViewSet  # , CarrierLoadViewSet
 
 app_name = 'load'
 

--- a/loadsmart/settings.py
+++ b/loadsmart/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'widget_tweaks',
     'bootstrap_modal_forms',
     'rest_framework',
+    'rest_framework.authtoken',
     'django_nose',
     'app',
     'users',

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from django.contrib.auth.views import LoginView, LogoutView
 from . import views
+from rest_framework.authtoken.views import obtain_auth_token
 
 app_name = 'users'
 
@@ -11,4 +12,6 @@ urlpatterns = [
          name='register_shipper'),
     path('register_carrier/', views.CarrierRegistrationView.as_view(),
          name='register_carrier'),
+    path('token/', obtain_auth_token),
+
 ]


### PR DESCRIPTION
every user must be authenticated to access API.
this authentication uses token method .
an user can use the follow endpoint to get their token using POST method and providing username and password.
localhost:8000/users/token/

carriers only can access carriers' endpoints
shippers only can access shipper's endpoints

shippers can now see the carrier's mc_number if their load have accepted status.
fix tests.